### PR TITLE
Fix loading IdentityUserByUserName in MigrateToV6()

### DIFF
--- a/RavenDB.Identity/UserStore.cs
+++ b/RavenDB.Identity/UserStore.cs
@@ -803,7 +803,8 @@ namespace Raven.Identity
             using (var dbSession = docStore.OpenSession())
             {
 #pragma warning disable CS0618 // Type or member is obsolete
-                var stream = dbSession.Advanced.Stream<IdentityUserByUserName>("IdentityUserByUserNames/");
+                var collectionName = docStore.Conventions.FindCollectionName(typeof(IdentityUserByUserName));
+                var stream = dbSession.Advanced.Stream<IdentityUserByUserName>($"{collectionName}/");
 #pragma warning restore CS0618 // Type or member is obsolete
                 while (stream.MoveNext())
                 {


### PR DESCRIPTION
#11 Fix loading IdentityUserByUserName in UserStore.MigrateToV6() because of hard coded document prefix.