### PR TITLE
Changed ID creation to use TransformTypeCollectionNameToDocumentIdPrefix for collection name.

### DIFF
--- a/RavenDB.Identity/IdentityUserAuthToken.cs
+++ b/RavenDB.Identity/IdentityUserAuthToken.cs
@@ -49,9 +49,10 @@ namespace Raven.Identity
             var vals = new[] { userId, loginProvider, name }
                 .Select(v => v ?? "[null]");
             var collection = db.Conventions.GetCollectionName(typeof(IdentityUserAuthToken));
+			var prefix = db.Conventions.TransformTypeCollectionNameToDocumentIdPrefix(collection);
             var separator = db.Conventions.IdentityPartsSeparator;
             var valsHash = CalculateHash(string.Join("-", vals));
-            return collection + separator + valsHash.ToString();
+            return prefix + separator + valsHash.ToString();
         }
 
         private static int CalculateHash(string input)

--- a/RavenDB.Identity/RoleStore.cs
+++ b/RavenDB.Identity/RoleStore.cs
@@ -414,8 +414,9 @@ namespace Raven.Identity
         internal static string GetRavenIdFromRoleName(string role, IDocumentStore docStore)
         {
             var roleCollection = docStore.Conventions.GetCollectionName(typeof(TRole));
+			var prefix = docStore.Conventions.TransformTypeCollectionNameToDocumentIdPrefix(roleCollection);
             var partSeparator = docStore.Conventions.IdentityPartsSeparator;
-            return roleCollection + partSeparator + role;
+            return prefix + partSeparator + role;
         }
     }
 }

--- a/RavenDB.Identity/ServiceCollectionExtensions.cs
+++ b/RavenDB.Identity/ServiceCollectionExtensions.cs
@@ -50,7 +50,7 @@ namespace Raven.Identity
 					.AddDefaultTokenProviders();
 			}
 
-			services.AddScoped<Microsoft.AspNetCore.Identity.IUserStore<TUser>, UserStore<TUser>>();
+			services.AddScoped<Microsoft.AspNetCore.Identity.IUserStore<TUser>, UserStore<TUser, TRole>>();
 			services.AddScoped<Microsoft.AspNetCore.Identity.IRoleStore<TRole>, RoleStore<TRole>>();
 
 			return identityBuilder;

--- a/RavenDB.Identity/UserStore.cs
+++ b/RavenDB.Identity/UserStore.cs
@@ -16,7 +16,8 @@ namespace Raven.Identity
     /// UserStore for entities in a RavenDB database.
     /// </summary>
     /// <typeparam name="TUser"></typeparam>
-    public class UserStore<TUser> : 
+	/// <typeparam name="TRole"></typeparam>
+    public class UserStore<TUser, TRole> : 
         IUserStore<TUser>, 
         IUserLoginStore<TUser>, 
         IUserClaimStore<TUser>, 
@@ -32,6 +33,7 @@ namespace Raven.Identity
         IUserTwoFactorRecoveryCodeStore<TUser>,
         IQueryableUserStore<TUser>
         where TUser : IdentityUser
+		where TRole : IdentityRole
     {
         private bool _disposed;
         private readonly Func<IAsyncDocumentSession> getSessionFunc;
@@ -390,7 +392,7 @@ namespace Raven.Identity
             ThrowIfNullDisposedCancelled(user, cancellationToken);            
 
             // See if we have an IdentityRole with that name.
-            var identityUserCollection = DbSession.Advanced.DocumentStore.Conventions.GetCollectionName(typeof(IdentityRole));
+            var identityUserCollection = DbSession.Advanced.DocumentStore.Conventions.GetCollectionName(typeof(TRole));
 			var prefix = DbSession.Advanced.DocumentStore.Conventions.TransformTypeCollectionNameToDocumentIdPrefix(identityUserCollection);
             var identityPartSeperator = DbSession.Advanced.DocumentStore.Conventions.IdentityPartsSeparator;
             var roleNameLowered = roleName.ToLowerInvariant();
@@ -423,7 +425,7 @@ namespace Raven.Identity
 
             user.GetRolesList().RemoveAll(r => string.Equals(r, roleName, StringComparison.InvariantCultureIgnoreCase));
 
-            var roleId = RoleStore<IdentityRole>.GetRavenIdFromRoleName(roleName, DbSession.Advanced.DocumentStore);
+            var roleId = RoleStore<TRole>.GetRavenIdFromRoleName(roleName, DbSession.Advanced.DocumentStore);
             var roleOrNull = await DbSession.LoadAsync<IdentityRole>(roleId, cancellationToken);
             if (roleOrNull != null)
             {

--- a/RavenDB.Identity/UserStore.cs
+++ b/RavenDB.Identity/UserStore.cs
@@ -129,8 +129,9 @@ namespace Raven.Identity
             {
                 var conventions = DbSession.Advanced.DocumentStore.Conventions;
                 var entityName = conventions.GetCollectionName(typeof(TUser));
+				var prefix = conventions.TransformTypeCollectionNameToDocumentIdPrefix(entityName);
                 var separator = conventions.IdentityPartsSeparator;
-                var id = $"{entityName}{separator}{user.Email}";
+                var id = $"{prefix}{separator}{user.Email}";
                 user.Id = id;
             }
 
@@ -389,10 +390,11 @@ namespace Raven.Identity
             ThrowIfNullDisposedCancelled(user, cancellationToken);            
 
             // See if we have an IdentityRole with that name.
-            var identityUserPrefix = DbSession.Advanced.DocumentStore.Conventions.GetCollectionName(typeof(IdentityRole));
+            var identityUserCollection = DbSession.Advanced.DocumentStore.Conventions.GetCollectionName(typeof(IdentityRole));
+			var prefix = DbSession.Advanced.DocumentStore.Conventions.TransformTypeCollectionNameToDocumentIdPrefix(identityUserCollection);
             var identityPartSeperator = DbSession.Advanced.DocumentStore.Conventions.IdentityPartsSeparator;
             var roleNameLowered = roleName.ToLowerInvariant();
-            var roleId = identityUserPrefix + identityPartSeperator + roleNameLowered;
+            var roleId = prefix + identityPartSeperator + roleNameLowered;
             var existingRoleOrNull = await this.DbSession.LoadAsync<IdentityRole>(roleId, cancellationToken);
             if (existingRoleOrNull == null)
             {


### PR DESCRIPTION
I noticed that in most cases the collection names were lowercase, but if the collection name had multiple uppercase, it would stay the same. I then found this post. https://groups.google.com/forum/#!searchin/ravendb/id$20lowercase|sort:date/ravendb/vX4D6ysfS4c/Nc1QF2xABAAJ

This commit changes the ID creation to use `Conventions.TransformTypeCollectionNameToDocumentIdPrefix` for the prefix to match how the RavenDB client creates them.

I saw you've created a migration script for changes in the past. This does not include a migration upgrade method.