### PR TITLE
Fixed issue with UserStore.CreateAsync not updating if the UserName d…

### DIFF
--- a/RavenDB.Identity/IdentityBuilderExtensions.cs
+++ b/RavenDB.Identity/IdentityBuilderExtensions.cs
@@ -7,53 +7,37 @@ using System;
 
 namespace Raven.Identity
 {
-    /// <summary>
-    /// Extends the <see cref="IServiceCollection"/> so that RavenDB services can be registered through it.
-    /// </summary>
-    public static class IdentityBuilderExtensions
+	/// <summary>
+	/// Extends <see cref="IdentityBuilder"/> so that RavenDB services can be registered through it.
+	/// </summary>
+	public static class IdentityBuilderExtensions
     {
-        /// <summary>
-        /// Registers a RavenDB as the user store.
-        /// </summary>
-        /// <typeparam name="TUser">The type of user. This should be a class you created derived from <see cref="IdentityUser"/>.</typeparam>
-        /// <param name="services"></param>
-        /// <param name="setupAction">Identity options configuration.</param>
-        /// <returns>The identity builder.</returns>
-        public static IdentityBuilder AddRavenDbIdentity<TUser>(this IServiceCollection services, Action<IdentityOptions> setupAction = null)
-            where TUser : IdentityUser
-        {
-			return AddRavenDbIdentity<TUser, IdentityRole>(services, setupAction);
-        }
+		/// <summary>
+		/// Registers a RavenDB as the user store.
+		/// </summary>
+		/// <typeparam name="TUser">The type of the user.</typeparam>
+		/// <param name="builder">The builder.</param>
+		/// <returns></returns>
+		public static IdentityBuilder AddRavenDbStores<TUser>(this IdentityBuilder builder) where TUser : IdentityUser
+		{
+			return builder.AddRavenDbStores<TUser, IdentityRole>();
+		}
 
 		/// <summary>
 		/// Registers a RavenDB as the user store.
 		/// </summary>
-		/// <typeparam name="TUser">The type of user. This should be a class you created derived from <see cref="IdentityUser"/>.</typeparam>
-		/// <typeparam name="TRole">The type of role. This should be a class you created derived from <see cref="IdentityRole"/>.</typeparam>
-		/// <param name="services"></param>
-		/// <param name="setupAction">Identity options configuration.</param>
-		/// <returns>The identity builder.</returns>
-		public static IdentityBuilder AddRavenDbIdentity<TUser, TRole>(this IServiceCollection services, Action<IdentityOptions> setupAction = null)
+		/// <typeparam name="TUser">The type of the user.</typeparam>
+		/// <typeparam name="TRole">The type of the role.</typeparam>
+		/// <param name="builder">The builder.</param>
+		/// <returns>The builder.</returns>
+		public static IdentityBuilder AddRavenDbStores<TUser, TRole>(this IdentityBuilder builder)
 			where TUser : IdentityUser
 			where TRole : IdentityRole, new()
 		{
-            // Add the AspNet identity system to work with our RavenDB identity objects.
-            IdentityBuilder identityBuilder;
-			if (setupAction != null)
-			{
-				identityBuilder = services.AddIdentity<TUser, TRole>(setupAction)
-					.AddDefaultTokenProviders();
-			}
-			else
-			{
-				identityBuilder = services.AddIdentity<TUser, TRole>()
-					.AddDefaultTokenProviders();
-			}
+			builder.Services.AddScoped<IUserStore<TUser>, UserStore<TUser, TRole>>();
+			builder.Services.AddScoped<IRoleStore<TRole>, RoleStore<TRole>>();
 
-			services.AddScoped<Microsoft.AspNetCore.Identity.IUserStore<TUser>, UserStore<TUser, TRole>>();
-			services.AddScoped<Microsoft.AspNetCore.Identity.IRoleStore<TRole>, RoleStore<TRole>>();
-
-			return identityBuilder;
+			return builder;
 		}
-    }
+	}
 }

--- a/RavenDB.Identity/RavenDB.Identity.csproj
+++ b/RavenDB.Identity/RavenDB.Identity.csproj
@@ -29,8 +29,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Identity" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.0" />
     <PackageReference Include="RavenDB.Client" Version="4.2.4" />
     <PackageReference Include="RavenDB.DependencyInjection" Version="3.1.0" />
     <None Include="nuget-icon.png" Pack="true" PackagePath="" />


### PR DESCRIPTION
…idn't change.

Fixed issue with UserStore.CreateAsync using the UserName instead of Email for the compare/exchange.
Fixed issue with UserStore.FindByNameAsync looking in the compare/exchange for the user name when it holds emails.
Update project Microsoft references to 3.1.0. Microsoft.AspNetCore.Identity only goes to 2.2, so it was swapped with Microsoft.Extensions.Identity.Core 3.1.0
Changed IdentityBuilderExtensions to build off of IdentityBuilder instead of IServiceCollection due to the 3.1.0 update.