### PR TITLE
Support for stable (unchanging) User Ids

### DIFF
--- a/RavenDB.Identity/IdentityBuilderExtensions.cs
+++ b/RavenDB.Identity/IdentityBuilderExtensions.cs
@@ -12,28 +12,32 @@ namespace Raven.Identity
 	/// </summary>
 	public static class IdentityBuilderExtensions
     {
-		/// <summary>
-		/// Registers a RavenDB as the user store.
-		/// </summary>
-		/// <typeparam name="TUser">The type of the user.</typeparam>
-		/// <param name="builder">The builder.</param>
-		/// <returns></returns>
-		public static IdentityBuilder AddRavenDbIdentityStores<TUser>(this IdentityBuilder builder) where TUser : IdentityUser
+	    /// <summary>
+	    /// Registers a RavenDB as the user store.
+	    /// </summary>
+	    /// <typeparam name="TUser">The type of the user.</typeparam>
+	    /// <param name="builder">The builder.</param>
+	    /// <param name="configure">Configure options for Raven Identity</param>
+	    /// <returns></returns>
+	    public static IdentityBuilder AddRavenDbIdentityStores<TUser>(this IdentityBuilder builder, Action<RavenIdentityOptions> configure = null) where TUser : IdentityUser
 		{
-			return builder.AddRavenDbIdentityStores<TUser, IdentityRole>();
+			return builder.AddRavenDbIdentityStores<TUser, IdentityRole>(configure);
 		}
 
-		/// <summary>
-		/// Registers a RavenDB as the user store.
-		/// </summary>
-		/// <typeparam name="TUser">The type of the user.</typeparam>
-		/// <typeparam name="TRole">The type of the role.</typeparam>
-		/// <param name="builder">The builder.</param>
-		/// <returns>The builder.</returns>
-		public static IdentityBuilder AddRavenDbIdentityStores<TUser, TRole>(this IdentityBuilder builder)
+	    /// <summary>
+	    /// Registers a RavenDB as the user store.
+	    /// </summary>
+	    /// <typeparam name="TUser">The type of the user.</typeparam>
+	    /// <typeparam name="TRole">The type of the role.</typeparam>
+	    /// <param name="builder">The builder.</param>
+	    /// <param name="configure">Configure options for Raven Identity</param>
+	    /// <returns>The builder.</returns>
+	    public static IdentityBuilder AddRavenDbIdentityStores<TUser, TRole>(this IdentityBuilder builder, Action<RavenIdentityOptions> configure = null)
 			where TUser : IdentityUser
 			where TRole : IdentityRole, new()
 		{
+			configure ??= options => {};
+			builder.Services.Configure(configure);
 			builder.Services.AddScoped<IUserStore<TUser>, UserStore<TUser, TRole>>();
 			builder.Services.AddScoped<IRoleStore<TRole>, RoleStore<TRole>>();
 

--- a/RavenDB.Identity/IdentityBuilderExtensions.cs
+++ b/RavenDB.Identity/IdentityBuilderExtensions.cs
@@ -41,7 +41,6 @@ namespace Raven.Identity
 	    /// <typeparam name="TUser">The type of the user.</typeparam>
 	    /// <typeparam name="TRole">The type of the role.</typeparam>
 	    /// <param name="builder">The builder.</param>
-	    /// <param name="configure">Configure options for Raven Identity</param>
 	    /// <returns>The builder.</returns>
 	    public static IdentityBuilder AddRavenDbIdentityStores<TUser, TRole>(this IdentityBuilder builder)
 		    where TUser : IdentityUser

--- a/RavenDB.Identity/IdentityBuilderExtensions.cs
+++ b/RavenDB.Identity/IdentityBuilderExtensions.cs
@@ -17,9 +17,20 @@ namespace Raven.Identity
 	    /// </summary>
 	    /// <typeparam name="TUser">The type of the user.</typeparam>
 	    /// <param name="builder">The builder.</param>
+	    /// <returns></returns>
+	    public static IdentityBuilder AddRavenDbIdentityStores<TUser>(this IdentityBuilder builder) where TUser : IdentityUser
+	    {
+		    return builder.AddRavenDbIdentityStores<TUser, IdentityRole>(c => { });
+	    }
+
+	    /// <summary>
+	    /// Registers a RavenDB as the user store.
+	    /// </summary>
+	    /// <typeparam name="TUser">The type of the user.</typeparam>
+	    /// <param name="builder">The builder.</param>
 	    /// <param name="configure">Configure options for Raven Identity</param>
 	    /// <returns></returns>
-	    public static IdentityBuilder AddRavenDbIdentityStores<TUser>(this IdentityBuilder builder, Action<RavenIdentityOptions>? configure = null) where TUser : IdentityUser
+	    public static IdentityBuilder AddRavenDbIdentityStores<TUser>(this IdentityBuilder builder, Action<RavenIdentityOptions> configure) where TUser : IdentityUser
 		{
 			return builder.AddRavenDbIdentityStores<TUser, IdentityRole>(configure);
 		}
@@ -32,11 +43,25 @@ namespace Raven.Identity
 	    /// <param name="builder">The builder.</param>
 	    /// <param name="configure">Configure options for Raven Identity</param>
 	    /// <returns>The builder.</returns>
-	    public static IdentityBuilder AddRavenDbIdentityStores<TUser, TRole>(this IdentityBuilder builder, Action<RavenIdentityOptions>? configure = null)
+	    public static IdentityBuilder AddRavenDbIdentityStores<TUser, TRole>(this IdentityBuilder builder)
+		    where TUser : IdentityUser
+		    where TRole : IdentityRole, new()
+	    {
+		    return builder.AddRavenDbIdentityStores<TUser, TRole>(c => { });
+	    }
+
+	    /// <summary>
+	    /// Registers a RavenDB as the user store.
+	    /// </summary>
+	    /// <typeparam name="TUser">The type of the user.</typeparam>
+	    /// <typeparam name="TRole">The type of the role.</typeparam>
+	    /// <param name="builder">The builder.</param>
+	    /// <param name="configure">Configure options for Raven Identity</param>
+	    /// <returns>The builder.</returns>
+	    public static IdentityBuilder AddRavenDbIdentityStores<TUser, TRole>(this IdentityBuilder builder, Action<RavenIdentityOptions> configure)
 			where TUser : IdentityUser
 			where TRole : IdentityRole, new()
 		{
-			configure ??= options => {};
 			builder.Services.Configure(configure);
 			builder.Services.AddScoped<IUserStore<TUser>, UserStore<TUser, TRole>>();
 			builder.Services.AddScoped<IRoleStore<TRole>, RoleStore<TRole>>();

--- a/RavenDB.Identity/IdentityBuilderExtensions.cs
+++ b/RavenDB.Identity/IdentityBuilderExtensions.cs
@@ -19,7 +19,7 @@ namespace Raven.Identity
 	    /// <param name="builder">The builder.</param>
 	    /// <param name="configure">Configure options for Raven Identity</param>
 	    /// <returns></returns>
-	    public static IdentityBuilder AddRavenDbIdentityStores<TUser>(this IdentityBuilder builder, Action<RavenIdentityOptions> configure = null) where TUser : IdentityUser
+	    public static IdentityBuilder AddRavenDbIdentityStores<TUser>(this IdentityBuilder builder, Action<RavenIdentityOptions>? configure = null) where TUser : IdentityUser
 		{
 			return builder.AddRavenDbIdentityStores<TUser, IdentityRole>(configure);
 		}
@@ -32,7 +32,7 @@ namespace Raven.Identity
 	    /// <param name="builder">The builder.</param>
 	    /// <param name="configure">Configure options for Raven Identity</param>
 	    /// <returns>The builder.</returns>
-	    public static IdentityBuilder AddRavenDbIdentityStores<TUser, TRole>(this IdentityBuilder builder, Action<RavenIdentityOptions> configure = null)
+	    public static IdentityBuilder AddRavenDbIdentityStores<TUser, TRole>(this IdentityBuilder builder, Action<RavenIdentityOptions>? configure = null)
 			where TUser : IdentityUser
 			where TRole : IdentityRole, new()
 		{

--- a/RavenDB.Identity/RavenIdentityOptions.cs
+++ b/RavenDB.Identity/RavenIdentityOptions.cs
@@ -1,0 +1,17 @@
+namespace Raven.Identity
+{
+    /// <summary>
+    /// Options for Raven Identity storage.
+    /// </summary>
+    public class RavenIdentityOptions
+    {
+        /// <summary>
+        /// If set to true, this will use a server generated id for the User Id. In this case, changing the user email address
+        /// has no effect on the User Id. If set to false, changing the users email address will change their User Id. Default
+        /// is false.
+        /// </summary>
+        /// <remarks>It is critical this value is not changed once users have been stored in RavenDb. Doing so will result
+        /// in strange behavior and probably loss of data.</remarks>
+        public bool StableUserId { get; set; } = false;
+    }
+}

--- a/RavenDB.Identity/UserStore.cs
+++ b/RavenDB.Identity/UserStore.cs
@@ -603,6 +603,10 @@ namespace Raven.Identity
         {
             var getReq = new GetCompareExchangeValueOperation<string>(GetCompareExchangeKeyFromEmail(normalizedEmail));
             var idResult = await DbSession.Advanced.DocumentStore.Operations.SendAsync(getReq, token: cancellationToken);
+            if (idResult == null)
+            {
+                return null;
+            }
             return await DbSession.LoadAsync<TUser>(idResult.Value, cancellationToken);
         }
 

--- a/RavenDB.Identity/UserStore.cs
+++ b/RavenDB.Identity/UserStore.cs
@@ -641,7 +641,9 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
+#pragma warning disable 8632
         public async Task<TUser> FindByEmailAsync(string normalizedEmail, CancellationToken cancellationToken)
+#pragma warning restore 8632
         {
             var getReq = new GetCompareExchangeValueOperation<string>(GetCompareExchangeKeyFromEmail(normalizedEmail));
             var idResult = await DbSession.Advanced.DocumentStore.Operations.SendAsync(getReq, token: cancellationToken);

--- a/RavenDB.Identity/UserStore.cs
+++ b/RavenDB.Identity/UserStore.cs
@@ -641,15 +641,15 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-#pragma warning disable 8632
         public async Task<TUser> FindByEmailAsync(string normalizedEmail, CancellationToken cancellationToken)
-#pragma warning restore 8632
         {
             var getReq = new GetCompareExchangeValueOperation<string>(GetCompareExchangeKeyFromEmail(normalizedEmail));
             var idResult = await DbSession.Advanced.DocumentStore.Operations.SendAsync(getReq, token: cancellationToken);
             if (idResult == null)
             {
+                #pragma warning disable 8603
                 return null;
+                #pragma warning restore 8603
             }
             return await DbSession.LoadAsync<TUser>(idResult.Value, cancellationToken);
         }

--- a/RavenDB.Identity/UserStore.cs
+++ b/RavenDB.Identity/UserStore.cs
@@ -987,20 +987,20 @@ namespace Raven.Identity
             return await store.Operations.SendAsync(updateEmailUserIdOperation);
         }
 
-		private Task<CompareExchangeResult<string>> DeleteUserKeyReservation(string email)
+		private async Task<CompareExchangeResult<string>> DeleteUserKeyReservation(string email)
         {
             var key = GetCompareExchangeKeyFromEmail(email);
             var store = DbSession.Advanced.DocumentStore;
 
-            var readResult = store.Operations.Send(new GetCompareExchangeValueOperation<string>(key));
+            var readResult = await store.Operations.SendAsync(new GetCompareExchangeValueOperation<string>(key));
             if (readResult == null)
             {
                 _logger.LogError("Failed to get current index for {EmailReservation} to delete it", key);
-                return Task.FromResult(new CompareExchangeResult<string>() { Successful = false });
+                return new CompareExchangeResult<string>() { Successful = false };
             }
 
             var deleteEmailOperation = new DeleteCompareExchangeValueOperation<string>(key, readResult.Index);
-            return DbSession.Advanced.DocumentStore.Operations.SendAsync(deleteEmailOperation);
+            return await DbSession.Advanced.DocumentStore.Operations.SendAsync(deleteEmailOperation);
         }
 
         private static string GetCompareExchangeKeyFromEmail(string email)

--- a/Readme.md
+++ b/Readme.md
@@ -29,7 +29,7 @@ public class AppUser : Raven.Identity.IdentityUser
 },
 ```
 
-3. In [Startup.cs](https://github.com/JudahGabriel/RavenDB.Identity/blob/master/Samples/RazorPages/Startup.cs), wire it all up:
+3a. In [Startup.cs](https://github.com/JudahGabriel/RavenDB.Identity/blob/master/Samples/RazorPages/Startup.cs), wire it all up. Note that this approach will use the email address as part of the User Id, such that changing their email will change their User Id as well:
 
 ```csharp
 public void ConfigureServices(IServiceCollection services)
@@ -57,6 +57,21 @@ public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
     ...
 }
 ```
+
+3.a. If you want to be able to change the email address of a user without also changing their user id, enable `StableUserId` mode:
+```csharp
+public void ConfigureServices(IServiceCollection services)
+{
+    // Everything else the same as above, just pass a configuration delegate to AddRavenDbIdentityStore(
+    services
+        .AddRavenDbDocStore() // Create an IDocumentStore singleton from the RavenSettings.
+        .AddRavenDbAsyncSession() // Create a RavenDB IAsyncDocumentSession for each request. You're responsible for calling .SaveChanges after each request.
+        .AddIdentity<AppUser, IdentityRole>() // Adds an identity system to ASP.NET Core
+        .AddRavenDbIdentityStores<AppUser>(o => o.StableUserId = true); // Use RavenDB as the store for identity users and roles, in StableUserId mode.
+    ...
+}
+```
+Be aware that changing `StableUserId` mode on an existing database is not supported, and will likely result in data loss.
 
 4. In your controller actions, [call .SaveChangesAsync() when you're done making changes](https://github.com/JudahGabriel/RavenDB.Identity/blob/master/Samples/RazorPages/Filters/RavenSaveChangesAsyncFilter.cs#L35). Typically this is done via a [RavenController base class](https://github.com/JudahGabriel/RavenDB.Identity/blob/master/Samples/Mvc/Controllers/RavenController.cs) for MVC/WebAPI projects or via a [page filter](https://github.com/JudahGabriel/RavenDB.Identity/blob/master/Samples/RazorPages/Filters/RavenSaveChangesAsyncFilter.cs) for Razor Pages projects.
 
@@ -91,6 +106,10 @@ Previous versions of RavenDB.Identity had relied on `IdentityUserByUserName` IDs
 ## Getting Started and Sample Project
 
 Need help? Checkout the [Razor Pages sample](https://github.com/JudahGabriel/RavenDB.Identity/tree/master/Samples/RazorPages) or [MVC sample](https://github.com/JudahGabriel/RavenDB.Identity/tree/master/Samples/Mvc) to see it all in action.
+
+## Stable User Id mode
+
+By default RavenDB.Identity will use the email address of the user as part of their unique user Id, for example `Users/user@email.com`. This is great for readability while debugging, but if your application needs to allow the user to change their email address without losing their existing data it can be a real pain. The reason is that other documents will [likely have references](https://ravendb.net/docs/article-page/4.2/Csharp/client-api/how-to/handle-document-relationships) to the User Id, so if a user changes their email address but wants to keep the same account & data you would have to write code that updated those references. To help alleviate this pain you can use RavenDB.Identity in a different configuration where it will let RavenDB generate a unique ID for each user (eg: `Users/7-A`), which means their email can change without affecting their User Id and all references to the User document stay valid when their email address changes. *Be aware, changing StableUserId mode on a database with existing User documents is not supported, and will almost certainly result in loss of data.* If you think your application might ever need to support users changing their email address, it is recommended that you start your project using Stable User Id mode.
 
 ## Not using .NET Core?
 


### PR DESCRIPTION
This adds support for using a Raven-generated ID for Users, so that changing a Users email does not affect their Id. The default behavior should be unchanged from the existing Identity package (other than a few bug fixes mentioned below), so existing users of the package will not have anything break. By passing in a configuration option to RavenDb.Identity `.AddRavenDbIdentityStores<AppUser>(o => o.StableUserId = true)` the Stable User Id mode is enabled. With this enabled when a user changes their email address, the compare/exchange value for them is recreated with the new Email, and the Email property on their document is updated.

Also in this PR are some minor bug fixes for things I found while implementing this:
1. `FindUserByEmail` now uses the compare/exchange value to get their actual UserId, then calls `Load()` with that Id. This resolves an issue where a user could change their email address, and another call very shortly after would get a stale result because it was querying an index.
2. `Update` had error handling code that would attempt to recreate the compare/exchange value if an update failed, but the key value it was passing to the methods had already been formatted to the compare/exchange key, which resulted in the key being double-formatted (eg: `emails/emails/foo@bar.com`)
3. A few places that could pass a CancellationToken but weren't.

@JudahGabriel - I know you prefer `.ToLowerInvariant()` and I agree with you on that preference, but the dotnet core Identity components which are calling into this `UserStore`, such as `UserManager` are [expecting email/username to use ToUpperInvariant()](https://github.com/dotnet/aspnetcore/blob/master/src/Identity/Extensions.Core/src/UpperInvariantLookupNormalizer.cs). Given that, maybe Raven Identity should use the same approach for normalizing email & username? This `UserStore` could take a dependency on `ILookupNormalizer` from the framework and then have consistent behavior for however the user wants to configure normalization. If you are OK with this approach, I can make that change in a separate PR.