### PR TITLE
Ensure store methods are virtual for extendability

### DIFF
--- a/RavenDB.Identity/RavenDB.Identity.csproj
+++ b/RavenDB.Identity/RavenDB.Identity.csproj
@@ -27,11 +27,14 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageReleaseNotes>Fixed bug where calling AddToRolesAsync or RemoveFromRolesAsync with an empty enumerable resulted in an exception.</PackageReleaseNotes>
     <nullable>enable</nullable>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="3.1.6" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.6" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     <PackageReference Include="RavenDB.Client" Version="5.0.0" />
     <PackageReference Include="RavenDB.DependencyInjection" Version="4.0.0" />
     <None Include="nuget-icon.png" Pack="true" PackagePath="" />

--- a/RavenDB.Identity/RoleStore.cs
+++ b/RavenDB.Identity/RoleStore.cs
@@ -16,14 +16,14 @@ using Raven.Client.Documents;
 namespace Raven.Identity
 {
     /// <summary>
-    /// 
+    ///
     /// </summary>
     /// <typeparam name="TRole"></typeparam>
     public class RoleMan<TRole> : RoleManager<TRole>
         where TRole : class
     {
         /// <summary>
-        /// 
+        ///
         /// </summary>
         /// <param name="store"></param>
         /// <param name="roleValidators"></param>
@@ -31,10 +31,10 @@ namespace Raven.Identity
         /// <param name="errors"></param>
         /// <param name="logger"></param>
         public RoleMan(
-            IRoleStore<TRole> store, 
-            IEnumerable<IRoleValidator<TRole>> roleValidators, 
-            ILookupNormalizer keyNormalizer, 
-            IdentityErrorDescriber errors, 
+            IRoleStore<TRole> store,
+            IEnumerable<IRoleValidator<TRole>> roleValidators,
+            ILookupNormalizer keyNormalizer,
+            IdentityErrorDescriber errors,
             ILogger<RoleManager<TRole>> logger) :
             base(store, roleValidators, keyNormalizer, errors, logger)
         {
@@ -53,9 +53,9 @@ namespace Raven.Identity
         /// </summary>
         /// <param name="context">The <see cref="IAsyncDocumentSession"/>.</param>
         /// <param name="describer">The <see cref="IdentityErrorDescriber"/>.</param>
-        public RoleStore(IAsyncDocumentSession context, IdentityErrorDescriber? describer = null) 
-            : base(context, describer) 
-        { 
+        public RoleStore(IAsyncDocumentSession context, IdentityErrorDescriber? describer = null)
+            : base(context, describer)
+        {
         }
 
         /// <summary>
@@ -129,7 +129,7 @@ namespace Raven.Identity
         /// <param name="role">The role to create in the store.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
         /// <returns>A <see cref="Task{TResult}"/> that represents the <see cref="IdentityResult"/> of the asynchronous query.</returns>
-        public async virtual Task<IdentityResult> CreateAsync(TRole role, CancellationToken cancellationToken = default)
+        public virtual async Task<IdentityResult> CreateAsync(TRole role, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
@@ -154,7 +154,7 @@ namespace Raven.Identity
         /// <param name="role">The role to update in the store.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
         /// <returns>A <see cref="Task{TResult}"/> that represents the <see cref="IdentityResult"/> of the asynchronous query.</returns>
-        public async virtual Task<IdentityResult> UpdateAsync(TRole role, CancellationToken cancellationToken = default)
+        public virtual async Task<IdentityResult> UpdateAsync(TRole role, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
@@ -183,7 +183,7 @@ namespace Raven.Identity
         /// <param name="role">The role to delete from the store.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
         /// <returns>A <see cref="Task{TResult}"/> that represents the <see cref="IdentityResult"/> of the asynchronous query.</returns>
-        public async virtual Task<IdentityResult> DeleteAsync(TRole role, CancellationToken cancellationToken = default)
+        public virtual async Task<IdentityResult> DeleteAsync(TRole role, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
@@ -209,7 +209,7 @@ namespace Raven.Identity
         /// <param name="role">The role whose ID should be returned.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
         /// <returns>A <see cref="Task{TResult}"/> that contains the ID of the role.</returns>
-        public Task<string?> GetRoleIdAsync(TRole role, CancellationToken cancellationToken = default)
+        public virtual Task<string?> GetRoleIdAsync(TRole role, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
@@ -227,7 +227,7 @@ namespace Raven.Identity
         /// <param name="role">The role whose name should be returned.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
         /// <returns>A <see cref="Task{TResult}"/> that contains the name of the role.</returns>
-        public Task<string> GetRoleNameAsync(TRole role, CancellationToken cancellationToken = default)
+        public virtual Task<string> GetRoleNameAsync(TRole role, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
@@ -245,7 +245,7 @@ namespace Raven.Identity
         /// <param name="roleName">The name of the role.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation.</returns>
-        public Task SetRoleNameAsync(TRole role, string roleName, CancellationToken cancellationToken = default)
+        public virtual Task SetRoleNameAsync(TRole role, string roleName, CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
             ThrowIfDisposed();
@@ -336,7 +336,7 @@ namespace Raven.Identity
         /// <summary>
         /// Dispose the stores
         /// </summary>
-        public void Dispose()
+        public virtual void Dispose()
         {
             _disposed = true;
         }
@@ -347,7 +347,7 @@ namespace Raven.Identity
         /// <param name="role">The role whose claims should be retrieved.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
         /// <returns>A <see cref="Task{TResult}"/> that contains the claims granted to a role.</returns>
-        public async Task<IList<Claim>> GetClaimsAsync(TRole role, CancellationToken cancellationToken = default)
+        public virtual  async Task<IList<Claim>> GetClaimsAsync(TRole role, CancellationToken cancellationToken = default)
         {
             ThrowIfDisposed();
             if (role == null)
@@ -367,7 +367,7 @@ namespace Raven.Identity
         /// <param name="claim">The claim to add to the role.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation.</returns>
-        public Task AddClaimAsync(TRole role, Claim claim, CancellationToken cancellationToken = default)
+        public virtual Task AddClaimAsync(TRole role, Claim claim, CancellationToken cancellationToken = default)
         {
             ThrowIfDisposed();
             if (role == null)
@@ -390,7 +390,7 @@ namespace Raven.Identity
         /// <param name="claim">The claim to remove from the role.</param>
         /// <param name="cancellationToken">The <see cref="CancellationToken"/> used to propagate notifications that the operation should be canceled.</param>
         /// <returns>The <see cref="Task"/> that represents the asynchronous operation.</returns>
-        public async Task RemoveClaimAsync(TRole role, Claim claim, CancellationToken cancellationToken = default)
+        public virtual async Task RemoveClaimAsync(TRole role, Claim claim, CancellationToken cancellationToken = default)
         {
             ThrowIfDisposed();
             if (role == null)

--- a/RavenDB.Identity/UserStore.cs
+++ b/RavenDB.Identity/UserStore.cs
@@ -22,16 +22,16 @@ namespace Raven.Identity
     /// </summary>
     /// <typeparam name="TUser"></typeparam>
 	/// <typeparam name="TRole"></typeparam>
-    public class UserStore<TUser, TRole> : 
-        IUserStore<TUser>, 
-        IUserLoginStore<TUser>, 
-        IUserClaimStore<TUser>, 
+    public class UserStore<TUser, TRole> :
+        IUserStore<TUser>,
+        IUserLoginStore<TUser>,
+        IUserClaimStore<TUser>,
         IUserRoleStore<TUser>,
-        IUserPasswordStore<TUser>, 
-        IUserSecurityStampStore<TUser>, 
-        IUserEmailStore<TUser>, 
+        IUserPasswordStore<TUser>,
+        IUserSecurityStampStore<TUser>,
+        IUserEmailStore<TUser>,
         IUserLockoutStore<TUser>,
-        IUserTwoFactorStore<TUser>, 
+        IUserTwoFactorStore<TUser>,
         IUserPhoneNumberStore<TUser>,
         IUserAuthenticatorKeyStore<TUser>,
         IUserAuthenticationTokenStore<TUser>,
@@ -72,7 +72,7 @@ namespace Raven.Identity
         /// <summary>
         /// Disposes the user store.
         /// </summary>
-        public void Dispose()
+        public virtual void Dispose()
         {
             _disposed = true;
         }
@@ -82,30 +82,30 @@ namespace Raven.Identity
         #region IUserStore implementation
 
         /// <inheritdoc />
-        public Task<string?> GetUserIdAsync(TUser user, CancellationToken cancellationToken) => Task.FromResult(user.Id);
+        public virtual Task<string?> GetUserIdAsync(TUser user, CancellationToken cancellationToken) => Task.FromResult(user.Id);
 
         /// <inheritdoc />
-        public Task<string> GetUserNameAsync(TUser user, CancellationToken cancellationToken) => Task.FromResult(user.UserName);
+        public virtual Task<string> GetUserNameAsync(TUser user, CancellationToken cancellationToken) => Task.FromResult(user.UserName);
 
         /// <inheritdoc />
-        public Task SetUserNameAsync(TUser user, string userName, CancellationToken cancellationToken)
+        public virtual Task SetUserNameAsync(TUser user, string userName, CancellationToken cancellationToken)
         {
             user.UserName = userName;
             return Task.CompletedTask;
         }
 
         /// <inheritdoc />
-        public Task<string> GetNormalizedUserNameAsync(TUser user, CancellationToken cancellationToken) => Task.FromResult(user.UserName);
+        public virtual Task<string> GetNormalizedUserNameAsync(TUser user, CancellationToken cancellationToken) => Task.FromResult(user.UserName);
 
         /// <inheritdoc />
-        public Task SetNormalizedUserNameAsync(TUser user, string normalizedName, CancellationToken cancellationToken)
+        public virtual Task SetNormalizedUserNameAsync(TUser user, string normalizedName, CancellationToken cancellationToken)
         {
             user.UserName = normalizedName.ToLowerInvariant();
             return Task.CompletedTask;
         }
 
         /// <inheritdoc />
-        public async Task<IdentityResult> CreateAsync(TUser user, CancellationToken cancellationToken)
+        public virtual async Task<IdentityResult> CreateAsync(TUser user, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
 
@@ -119,7 +119,7 @@ namespace Raven.Identity
             // Normalize the email and user name.
             user.Email = email;
             user.UserName = user.UserName?.ToLowerInvariant() ?? email ?? string.Empty;
-            
+
 			// See if the email address is already taken.
 			// We do this using Raven's compare/exchange functionality, which works cluster-wide.
 			// https://ravendb.net/docs/article-page/4.1/csharp/client-api/operations/compare-exchange/overview#creating-a-key
@@ -174,7 +174,7 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-        public async Task<IdentityResult> UpdateAsync(TUser user, CancellationToken cancellationToken)
+        public virtual async Task<IdentityResult> UpdateAsync(TUser user, CancellationToken cancellationToken)
         {
 			ThrowIfNullDisposedCancelled(user, cancellationToken);
 
@@ -240,7 +240,7 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-        public async Task<IdentityResult> DeleteAsync(TUser user, CancellationToken cancellationToken)
+        public virtual async Task<IdentityResult> DeleteAsync(TUser user, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
             cancellationToken.ThrowIfCancellationRequested();
@@ -261,11 +261,11 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-        public Task<TUser> FindByIdAsync(string userId, CancellationToken cancellationToken) =>
+        public virtual Task<TUser> FindByIdAsync(string userId, CancellationToken cancellationToken) =>
             this.DbSession.LoadAsync<TUser>(userId, cancellationToken);
 
         /// <inheritdoc />
-        public Task<TUser> FindByNameAsync(string normalizedUserName, CancellationToken cancellationToken)
+        public virtual  Task<TUser> FindByNameAsync(string normalizedUserName, CancellationToken cancellationToken)
         {
             return DbSession.Query<TUser>()
                 .SingleOrDefaultAsync(u => u.UserName == normalizedUserName, cancellationToken);
@@ -276,7 +276,7 @@ namespace Raven.Identity
         #region IUserLoginStore implementation
 
         /// <inheritdoc />
-        public Task AddLoginAsync(TUser user, UserLoginInfo login, CancellationToken cancellationToken)
+        public virtual Task AddLoginAsync(TUser user, UserLoginInfo login, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
             if (login == null)
@@ -289,7 +289,7 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-        public Task RemoveLoginAsync(TUser user, string loginProvider, string providerKey, CancellationToken cancellationToken)
+        public virtual Task RemoveLoginAsync(TUser user, string loginProvider, string providerKey, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
             user.Logins.RemoveAll(l => l.LoginProvider == loginProvider && l.ProviderKey == providerKey);
@@ -297,14 +297,14 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-        public Task<IList<UserLoginInfo>> GetLoginsAsync(TUser user, CancellationToken cancellationToken)
+        public virtual Task<IList<UserLoginInfo>> GetLoginsAsync(TUser user, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
             return Task.FromResult(user.Logins as IList<UserLoginInfo>);
         }
 
         /// <inheritdoc />
-        public Task<TUser> FindByLoginAsync(string loginProvider, string providerKey, CancellationToken cancellationToken)
+        public virtual Task<TUser> FindByLoginAsync(string loginProvider, string providerKey, CancellationToken cancellationToken)
         {
             return DbSession.Query<TUser>()
                 .FirstOrDefaultAsync(u => u.Logins.Any(l => l.LoginProvider == loginProvider && l.ProviderKey == providerKey));
@@ -315,7 +315,7 @@ namespace Raven.Identity
         #region IUserClaimStore implementation
 
         /// <inheritdoc />
-        public Task<IList<Claim>> GetClaimsAsync(TUser user, CancellationToken cancellationToken)
+        public virtual Task<IList<Claim>> GetClaimsAsync(TUser user, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
 
@@ -326,7 +326,7 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-        public Task AddClaimsAsync(TUser user, IEnumerable<Claim> claims, CancellationToken cancellationToken)
+        public virtual Task AddClaimsAsync(TUser user, IEnumerable<Claim> claims, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
 
@@ -335,10 +335,10 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-        public async Task ReplaceClaimAsync(TUser user, Claim claim, Claim newClaim, CancellationToken cancellationToken)
+        public virtual async Task ReplaceClaimAsync(TUser user, Claim claim, Claim newClaim, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
-            
+
             var indexOfClaim = user.Claims.FindIndex(c => c.ClaimType == claim.Type && c.ClaimValue == claim.Value);
             if (indexOfClaim != -1)
             {
@@ -348,7 +348,7 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-        public Task RemoveClaimsAsync(TUser user, IEnumerable<Claim> claims, CancellationToken cancellationToken)
+        public virtual Task RemoveClaimsAsync(TUser user, IEnumerable<Claim> claims, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
 
@@ -357,7 +357,7 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-        public async Task<IList<TUser>> GetUsersForClaimAsync(Claim claim, CancellationToken cancellationToken)
+        public virtual async Task<IList<TUser>> GetUsersForClaimAsync(Claim claim, CancellationToken cancellationToken)
         {
             ThrowIfDisposedOrCancelled(cancellationToken);
             if (claim == null)
@@ -376,7 +376,7 @@ namespace Raven.Identity
         #region IUserRoleStore implementation
 
         /// <inheritdoc />
-        public async Task AddToRoleAsync(TUser user, string roleName, CancellationToken cancellationToken)
+        public virtual async Task AddToRoleAsync(TUser user, string roleName, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
 
@@ -407,7 +407,7 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-        public async Task RemoveFromRoleAsync(TUser user, string roleName, CancellationToken cancellationToken)
+        public virtual async Task RemoveFromRoleAsync(TUser user, string roleName, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
 
@@ -422,7 +422,7 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-        public Task<IList<string>> GetRolesAsync(TUser user, CancellationToken cancellationToken)
+        public virtual Task<IList<string>> GetRolesAsync(TUser user, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
 
@@ -430,7 +430,7 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-        public Task<bool> IsInRoleAsync(TUser user, string roleName, CancellationToken cancellationToken)
+        public virtual Task<bool> IsInRoleAsync(TUser user, string roleName, CancellationToken cancellationToken)
         {
             if (string.IsNullOrEmpty(roleName))
             {
@@ -441,7 +441,7 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-        public async Task<IList<TUser>> GetUsersInRoleAsync(string roleName, CancellationToken cancellationToken)
+        public virtual async Task<IList<TUser>> GetUsersInRoleAsync(string roleName, CancellationToken cancellationToken)
         {
             ThrowIfDisposedOrCancelled(cancellationToken);
             if (string.IsNullOrEmpty(roleName))
@@ -461,7 +461,7 @@ namespace Raven.Identity
         #region IUserPasswordStore implementation
 
         /// <inheritdoc />
-        public Task SetPasswordHashAsync(TUser user, string passwordHash, CancellationToken cancellationToken)
+        public virtual Task SetPasswordHashAsync(TUser user, string passwordHash, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
 
@@ -470,14 +470,14 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-        public Task<string?> GetPasswordHashAsync(TUser user, CancellationToken cancellationToken)
+        public virtual Task<string?> GetPasswordHashAsync(TUser user, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
             return Task.FromResult(user.PasswordHash);
         }
 
         /// <inheritdoc />
-        public Task<bool> HasPasswordAsync(TUser user, CancellationToken cancellationToken)
+        public virtual Task<bool> HasPasswordAsync(TUser user, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
             return Task.FromResult(user.PasswordHash != null);
@@ -488,7 +488,7 @@ namespace Raven.Identity
         #region IUserSecurityStampStore implementation
 
         /// <inheritdoc />
-        public Task SetSecurityStampAsync(TUser user, string stamp, CancellationToken cancellationToken)
+        public virtual Task SetSecurityStampAsync(TUser user, string stamp, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
 
@@ -497,7 +497,7 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-        public Task<string?> GetSecurityStampAsync(TUser user, CancellationToken cancellationToken)
+        public virtual Task<string?> GetSecurityStampAsync(TUser user, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
 
@@ -509,7 +509,7 @@ namespace Raven.Identity
         #region IUserEmailStore implementation
 
         /// <inheritdoc />
-        public Task SetEmailAsync(TUser user, string email, CancellationToken cancellationToken)
+        public virtual Task SetEmailAsync(TUser user, string email, CancellationToken cancellationToken)
         {
             ThrowIfDisposedOrCancelled(cancellationToken);
             user.Email = email?.ToLowerInvariant() ?? throw new ArgumentNullException(nameof(email));
@@ -517,33 +517,33 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-        public Task<string> GetEmailAsync(TUser user, CancellationToken cancellationToken) => 
+        public virtual Task<string> GetEmailAsync(TUser user, CancellationToken cancellationToken) =>
             Task.FromResult(user.Email);
 
         /// <inheritdoc />
-        public Task<bool> GetEmailConfirmedAsync(TUser user, CancellationToken cancellationToken) => 
+        public virtual Task<bool> GetEmailConfirmedAsync(TUser user, CancellationToken cancellationToken) =>
             Task.FromResult(user.EmailConfirmed);
 
         /// <inheritdoc />
-        public Task SetEmailConfirmedAsync(TUser user, bool confirmed, CancellationToken cancellationToken)
+        public virtual Task SetEmailConfirmedAsync(TUser user, bool confirmed, CancellationToken cancellationToken)
         {
             user.EmailConfirmed = confirmed;
             return Task.CompletedTask;
         }
 
         /// <inheritdoc />
-        public Task<TUser> FindByEmailAsync(string normalizedEmail, CancellationToken cancellationToken)
+        public virtual Task<TUser> FindByEmailAsync(string normalizedEmail, CancellationToken cancellationToken)
         {
             return DbSession.Query<TUser>()
                 .FirstOrDefaultAsync(e => e.Email == normalizedEmail);
         }
 
         /// <inheritdoc />
-        public Task<string> GetNormalizedEmailAsync(TUser user, CancellationToken cancellationToken) =>
+        public virtual Task<string> GetNormalizedEmailAsync(TUser user, CancellationToken cancellationToken) =>
             Task.FromResult(user.Email);
 
         /// <inheritdoc />
-        public Task SetNormalizedEmailAsync(TUser user, string normalizedEmail, CancellationToken cancellationToken)
+        public virtual Task SetNormalizedEmailAsync(TUser user, string normalizedEmail, CancellationToken cancellationToken)
         {
             user.Email = normalizedEmail.ToLowerInvariant(); // I don't like the ALL CAPS default. We're going all lower.
             return Task.CompletedTask;
@@ -554,7 +554,7 @@ namespace Raven.Identity
         #region IUserLockoutStore implementation
 
         /// <inheritdoc />
-        public Task<DateTimeOffset?> GetLockoutEndDateAsync(TUser user, CancellationToken cancellationToken)
+        public virtual Task<DateTimeOffset?> GetLockoutEndDateAsync(TUser user, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
 
@@ -562,7 +562,7 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-        public Task SetLockoutEndDateAsync(TUser user, DateTimeOffset? lockoutEnd, CancellationToken cancellationToken)
+        public virtual Task SetLockoutEndDateAsync(TUser user, DateTimeOffset? lockoutEnd, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
 
@@ -571,7 +571,7 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-        public Task<int> IncrementAccessFailedCountAsync(TUser user, CancellationToken cancellationToken)
+        public virtual Task<int> IncrementAccessFailedCountAsync(TUser user, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
 
@@ -580,7 +580,7 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-        public Task ResetAccessFailedCountAsync(TUser user, CancellationToken cancellationToken)
+        public virtual Task ResetAccessFailedCountAsync(TUser user, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
 
@@ -589,7 +589,7 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-        public Task<int> GetAccessFailedCountAsync(TUser user, CancellationToken cancellationToken)
+        public virtual Task<int> GetAccessFailedCountAsync(TUser user, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
 
@@ -597,14 +597,14 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-        public Task<bool> GetLockoutEnabledAsync(TUser user, CancellationToken cancellationToken)
+        public virtual Task<bool> GetLockoutEnabledAsync(TUser user, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
             return Task.FromResult(user.LockoutEnabled);
         }
 
         /// <inheritdoc />
-        public Task SetLockoutEnabledAsync(TUser user, bool enabled, CancellationToken cancellationToken)
+        public virtual Task SetLockoutEnabledAsync(TUser user, bool enabled, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
 
@@ -617,7 +617,7 @@ namespace Raven.Identity
         #region IUserTwoFactorStore implementation
 
         /// <inheritdoc />
-        public Task SetTwoFactorEnabledAsync(TUser user, bool enabled, CancellationToken cancellationToken)
+        public virtual Task SetTwoFactorEnabledAsync(TUser user, bool enabled, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
 
@@ -626,7 +626,7 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-        public Task<bool> GetTwoFactorEnabledAsync(TUser user, CancellationToken cancellationToken)
+        public virtual Task<bool> GetTwoFactorEnabledAsync(TUser user, CancellationToken cancellationToken)
         {
             ThrowIfNullDisposedCancelled(user, cancellationToken);
 
@@ -638,22 +638,22 @@ namespace Raven.Identity
         #region IUserPhoneNumberStore implementation
 
         /// <inheritdoc />
-        public Task SetPhoneNumberAsync(TUser user, string phoneNumber, CancellationToken cancellationToken)
+        public virtual Task SetPhoneNumberAsync(TUser user, string phoneNumber, CancellationToken cancellationToken)
         {
             user.PhoneNumber = phoneNumber;
             return Task.CompletedTask;
         }
 
         /// <inheritdoc />
-        public Task<string?> GetPhoneNumberAsync(TUser user, CancellationToken cancellationToken) => 
+        public virtual Task<string?> GetPhoneNumberAsync(TUser user, CancellationToken cancellationToken) =>
             Task.FromResult(user.PhoneNumber);
 
         /// <inheritdoc />
-        public Task<bool> GetPhoneNumberConfirmedAsync(TUser user, CancellationToken cancellationToken) =>
+        public virtual Task<bool> GetPhoneNumberConfirmedAsync(TUser user, CancellationToken cancellationToken) =>
             Task.FromResult(user.PhoneNumberConfirmed);
 
         /// <inheritdoc />
-        public Task SetPhoneNumberConfirmedAsync(TUser user, bool confirmed, CancellationToken cancellationToken)
+        public virtual Task SetPhoneNumberConfirmedAsync(TUser user, bool confirmed, CancellationToken cancellationToken)
         {
             user.PhoneNumberConfirmed = confirmed;
             return Task.CompletedTask;
@@ -662,16 +662,16 @@ namespace Raven.Identity
         #endregion
 
         #region IUserAuthenticatorKeyStore implementation
-        
+
         /// <inheritdoc />
-        public Task SetAuthenticatorKeyAsync(TUser user, string key, CancellationToken cancellationToken)
+        public virtual Task SetAuthenticatorKeyAsync(TUser user, string key, CancellationToken cancellationToken)
         {
             user.TwoFactorAuthenticatorKey = key;
             return Task.CompletedTask;
         }
 
         /// <inheritdoc />
-        public Task<string?> GetAuthenticatorKeyAsync(TUser user, CancellationToken cancellationToken)
+        public virtual Task<string?> GetAuthenticatorKeyAsync(TUser user, CancellationToken cancellationToken)
         {
             return Task.FromResult(user.TwoFactorAuthenticatorKey);
         }
@@ -681,7 +681,7 @@ namespace Raven.Identity
         #region IUserAuthenticationTokenStore
 
         /// <inheritdoc />
-        public Task SetTokenAsync(TUser user, string loginProvider, string name, string value, CancellationToken cancellationToken)
+        public virtual Task SetTokenAsync(TUser user, string loginProvider, string name, string value, CancellationToken cancellationToken)
         {
             var existingToken = user.Tokens.FirstOrDefault(t => t.LoginProvider == loginProvider && t.Name == name);
             if (existingToken != null)
@@ -702,34 +702,34 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-        public Task RemoveTokenAsync(TUser user, string loginProvider, string name, CancellationToken cancellationToken)
+        public virtual Task RemoveTokenAsync(TUser user, string loginProvider, string name, CancellationToken cancellationToken)
         {
             user.Tokens.RemoveAll(t => t.LoginProvider == loginProvider && t.Name == name);
             return Task.CompletedTask;
         }
 
         /// <inheritdoc />
-        public Task<string?> GetTokenAsync(TUser user, string loginProvider, string name, CancellationToken cancellationToken)
+        public virtual Task<string?> GetTokenAsync(TUser user, string loginProvider, string name, CancellationToken cancellationToken)
         {
             var tokenOrNull = user.Tokens.FirstOrDefault(t => t.LoginProvider == loginProvider && t.Name == name);
             return Task.FromResult(tokenOrNull?.Value);
         }
-        
+
         /// <inheritdoc />
-        public Task ReplaceCodesAsync(TUser user, IEnumerable<string> recoveryCodes, CancellationToken cancellationToken)
+        public virtual Task ReplaceCodesAsync(TUser user, IEnumerable<string> recoveryCodes, CancellationToken cancellationToken)
         {
             user.TwoFactorRecoveryCodes = new List<string>(recoveryCodes);
             return Task.CompletedTask;
         }
 
         /// <inheritdoc />
-        public Task<bool> RedeemCodeAsync(TUser user, string code, CancellationToken cancellationToken)
+        public virtual Task<bool> RedeemCodeAsync(TUser user, string code, CancellationToken cancellationToken)
         {
             return Task.FromResult(user.TwoFactorRecoveryCodes.Remove(code));
         }
 
         /// <inheritdoc />
-        public Task<int> CountCodesAsync(TUser user, CancellationToken cancellationToken)
+        public virtual Task<int> CountCodesAsync(TUser user, CancellationToken cancellationToken)
         {
             return Task.FromResult(user.TwoFactorRecoveryCodes.Count);
         }
@@ -741,11 +741,14 @@ namespace Raven.Identity
         /// <summary>
         /// Gets the users as an IQueryable.
         /// </summary>
-        public IQueryable<TUser> Users => this.DbSession.Query<TUser>();
+        public virtual IQueryable<TUser> Users => this.DbSession.Query<TUser>();
 
         #endregion
 
-        private IAsyncDocumentSession DbSession
+        /// <summary>
+        /// Gets access to current session being used by this store.
+        /// </summary>
+        protected IAsyncDocumentSession DbSession
         {
             get
             {
@@ -785,7 +788,7 @@ namespace Raven.Identity
         /// <param name="email"></param>
         /// <param name="id"></param>
         /// <returns></returns>
-		private Task<CompareExchangeResult<string>> CreateEmailReservationAsync(string email, string id)
+        protected virtual Task<CompareExchangeResult<string>> CreateEmailReservationAsync(string email, string id)
 		{
 			var compareExchangeKey = Conventions.CompareExchangeKeyFor(email);
 			var reserveEmailOperation = new PutCompareExchangeValueOperation<string>(compareExchangeKey, id, 0);
@@ -798,7 +801,7 @@ namespace Raven.Identity
         /// <param name="email"></param>
         /// <param name="id"></param>
         /// <returns></returns>
-        private async Task<CompareExchangeResult<string>> UpdateEmailReservationAsync(string email, string id)
+        protected virtual async Task<CompareExchangeResult<string>> UpdateEmailReservationAsync(string email, string id)
         {
             var key = Conventions.CompareExchangeKeyFor(email);
             var store = DbSession.Advanced.DocumentStore;
@@ -814,7 +817,12 @@ namespace Raven.Identity
             return await store.Operations.SendAsync(updateEmailUserIdOperation);
         }
 
-		private async Task<CompareExchangeResult<string>> DeleteEmailReservation(string email)
+		/// <summary>
+		/// Removes email reservation.
+		/// </summary>
+		/// <param name="email"></param>
+		/// <returns></returns>
+		protected virtual async Task<CompareExchangeResult<string>> DeleteEmailReservation(string email)
         {
             var key = Conventions.CompareExchangeKeyFor(email);
             var store = DbSession.Advanced.DocumentStore;


### PR DESCRIPTION
Making methods virtual allows modifying the behavior without the requirement to rewrite whole store. Also added source link support that was missing.