### PR TITLE
Fix casting exception when adding user to role

### DIFF
--- a/RavenDB.Identity/IdentityUser.cs
+++ b/RavenDB.Identity/IdentityUser.cs
@@ -7,120 +7,122 @@ using Microsoft.AspNetCore.Identity;
 
 namespace Raven.Identity
 {
-    /// <summary>
-    /// Base user class for RavenDB Identity. Inherit from this class to add your own properties.
-    /// </summary>
-    public class IdentityUser
-    {
-        /// <summary>
-        /// The ID of the user.
-        /// </summary>
-        public virtual string? Id { get; set; }
+	/// <summary>
+	/// Base user class for RavenDB Identity. Inherit from this class to add your own properties.
+	/// </summary>
+	public class IdentityUser
+	{
+		private List<string> _roles = new List<string>();
 
-        /// <summary>
-        /// The user name. Usually the same as the email.
-        /// </summary>
-        public virtual string UserName { get; set; } = string.Empty;
+		/// <summary>
+		/// The ID of the user.
+		/// </summary>
+		public virtual string? Id { get; set; }
 
-        /// <summary>
-        /// The password hash.
-        /// </summary>
-        public virtual string? PasswordHash { get; set; }
+		/// <summary>
+		/// The user name. Usually the same as the email.
+		/// </summary>
+		public virtual string UserName { get; set; } = string.Empty;
 
-        /// <summary>
-        /// The security stamp.
-        /// </summary>
-        public virtual string? SecurityStamp { get; set; }
+		/// <summary>
+		/// The password hash.
+		/// </summary>
+		public virtual string? PasswordHash { get; set; }
 
-        /// <summary>
-        /// The concurrency stamp.
-        /// </summary>
-        public virtual string? ConcurrencyStamp { get; set; }
+		/// <summary>
+		/// The security stamp.
+		/// </summary>
+		public virtual string? SecurityStamp { get; set; }
 
-        /// <summary>
-        /// The email of the user.
-        /// </summary>
-        public virtual string Email { get; set; } = string.Empty;
+		/// <summary>
+		/// The concurrency stamp.
+		/// </summary>
+		public virtual string? ConcurrencyStamp { get; set; }
 
-        /// <summary>
-        /// The phone number.
-        /// </summary>
-        public virtual string? PhoneNumber { get; set; }
+		/// <summary>
+		/// The email of the user.
+		/// </summary>
+		public virtual string Email { get; set; } = string.Empty;
 
-        /// <summary>
-        /// Whether the user has confirmed their email address.
-        /// </summary>
-        public virtual bool EmailConfirmed { get; set; }
+		/// <summary>
+		/// The phone number.
+		/// </summary>
+		public virtual string? PhoneNumber { get; set; }
 
-        /// <summary>
-        /// Whether the user has confirmed their phone.
-        /// </summary>
-        public virtual bool PhoneNumberConfirmed { get; set; }
+		/// <summary>
+		/// Whether the user has confirmed their email address.
+		/// </summary>
+		public virtual bool EmailConfirmed { get; set; }
 
-        /// <summary>
-        /// Number of times sign in failed.
-        /// </summary>
-        public virtual int AccessFailedCount { get; set; }
+		/// <summary>
+		/// Whether the user has confirmed their phone.
+		/// </summary>
+		public virtual bool PhoneNumberConfirmed { get; set; }
 
-        /// <summary>
-        /// Whether the user is locked out.
-        /// </summary>
-        public virtual bool LockoutEnabled { get; set; }
+		/// <summary>
+		/// Number of times sign in failed.
+		/// </summary>
+		public virtual int AccessFailedCount { get; set; }
 
-        /// <summary>
-        /// When the user lock out is over.
-        /// </summary>
-        public virtual DateTimeOffset? LockoutEnd { get; set; }
+		/// <summary>
+		/// Whether the user is locked out.
+		/// </summary>
+		public virtual bool LockoutEnabled { get; set; }
 
-        /// <summary>
-        /// Whether 2-factor authentication is enabled.
-        /// </summary>
-        public virtual bool TwoFactorEnabled { get; set; }
+		/// <summary>
+		/// When the user lock out is over.
+		/// </summary>
+		public virtual DateTimeOffset? LockoutEnd { get; set; }
 
-        /// <summary>
-        /// The two-factor authenticator key.
-        /// </summary>
-        public string? TwoFactorAuthenticatorKey { get; set; }
+		/// <summary>
+		/// Whether 2-factor authentication is enabled.
+		/// </summary>
+		public virtual bool TwoFactorEnabled { get; set; }
 
-        /// <summary>
-        /// The roles of the user. To modify the user's roles, use <see cref="UserManager{TUser}.AddToRoleAsync(TUser, string)"/> and <see cref="UserManager{TUser}.RemoveFromRolesAsync(TUser, IEnumerable{string})"/>.
-        /// </summary>
-        public virtual IReadOnlyList<string> Roles { get; private set; } = new List<string>();
+		/// <summary>
+		/// The two-factor authenticator key.
+		/// </summary>
+		public string? TwoFactorAuthenticatorKey { get; set; }
 
-        /// <summary>
-        /// The user's claims, for use in claims-based authentication.
-        /// </summary>
-        public virtual List<IdentityUserClaim> Claims { get; private set; } = new List<IdentityUserClaim>();
+		/// <summary>
+		/// The roles of the user. To modify the user's roles, use <see cref="UserManager{TUser}.AddToRoleAsync(TUser, string)"/> and <see cref="UserManager{TUser}.RemoveFromRolesAsync(TUser, IEnumerable{string})"/>.
+		/// </summary>
+		public virtual IReadOnlyList<string> Roles { 
+			get => _roles; 
+			private set => _roles = value.ToList();
+		}
 
-        /// <summary>
-        /// The logins of the user.
-        /// </summary>
-        public virtual List<UserLoginInfo> Logins { get; private set; } = new List<UserLoginInfo>();
+		/// <summary>
+		/// The user's claims, for use in claims-based authentication.
+		/// </summary>
+		public virtual List<IdentityUserClaim> Claims { get; private set; } = new List<IdentityUserClaim>();
 
-        /// <summary>
-        /// The list of two factor authentication recovery codes.
-        /// </summary>
-        public virtual List<string> TwoFactorRecoveryCodes { get; set; } = new List<string>();
+		/// <summary>
+		/// The logins of the user.
+		/// </summary>
+		public virtual List<UserLoginInfo> Logins { get; private set; } = new List<UserLoginInfo>();
 
-        /// <summary>
-        /// The list authorization tokens from 3rd party authentication, e.g. Google, Microsoft, GitHub, etc.
-        /// </summary>
-        public virtual List<IdentityUserAuthToken> Tokens { get; set; } = new List<IdentityUserAuthToken>();
-        
-        /// <summary>
-        /// Gets the mutable roles list. This shouldn't be modified by user code; roles should be changed via UserManager instead.
-        /// </summary>
-        /// <returns></returns>
-        internal List<string> GetRolesList()
-        {
-            return (List<string>)this.Roles;
-        }
-    }
+		/// <summary>
+		/// The list of two factor authentication recovery codes.
+		/// </summary>
+		public virtual List<string> TwoFactorRecoveryCodes { get; set; } = new List<string>();
 
-    /// <summary>
-    /// A login claim.
-    /// </summary>
-    public class IdentityUserClaim
+		/// <summary>
+		/// The list authorization tokens from 3rd party authentication, e.g. Google, Microsoft, GitHub, etc.
+		/// </summary>
+		public virtual List<IdentityUserAuthToken> Tokens { get; set; } = new List<IdentityUserAuthToken>();
+
+		/// <summary>
+		/// Gets the mutable roles list. This shouldn't be modified by user code; roles should be changed via UserManager instead.
+		/// </summary>
+		/// <returns></returns>
+		internal List<string> GetRolesList() => _roles;
+	}
+
+	/// <summary>
+	/// A login claim.
+	/// </summary>
+	public class IdentityUserClaim
     {
         /// <summary>
         /// The type of the login claim.

--- a/RavenDB.Identity/IdentityUser.cs
+++ b/RavenDB.Identity/IdentityUser.cs
@@ -7,122 +7,122 @@ using Microsoft.AspNetCore.Identity;
 
 namespace Raven.Identity
 {
-	/// <summary>
-	/// Base user class for RavenDB Identity. Inherit from this class to add your own properties.
-	/// </summary>
-	public class IdentityUser
-	{
-		private List<string> _roles = new List<string>();
+    /// <summary>
+    /// Base user class for RavenDB Identity. Inherit from this class to add your own properties.
+    /// </summary>
+    public class IdentityUser
+    {
+        private List<string> _roles = new List<string>();
 
-		/// <summary>
-		/// The ID of the user.
-		/// </summary>
-		public virtual string? Id { get; set; }
+        /// <summary>
+        /// The ID of the user.
+        /// </summary>
+        public virtual string? Id { get; set; }
 
-		/// <summary>
-		/// The user name. Usually the same as the email.
-		/// </summary>
-		public virtual string UserName { get; set; } = string.Empty;
+        /// <summary>
+        /// The user name. Usually the same as the email.
+        /// </summary>
+        public virtual string UserName { get; set; } = string.Empty;
 
-		/// <summary>
-		/// The password hash.
-		/// </summary>
-		public virtual string? PasswordHash { get; set; }
+        /// <summary>
+        /// The password hash.
+        /// </summary>
+        public virtual string? PasswordHash { get; set; }
 
-		/// <summary>
-		/// The security stamp.
-		/// </summary>
-		public virtual string? SecurityStamp { get; set; }
+        /// <summary>
+        /// The security stamp.
+        /// </summary>
+        public virtual string? SecurityStamp { get; set; }
 
-		/// <summary>
-		/// The concurrency stamp.
-		/// </summary>
-		public virtual string? ConcurrencyStamp { get; set; }
+        /// <summary>
+        /// The concurrency stamp.
+        /// </summary>
+        public virtual string? ConcurrencyStamp { get; set; }
 
-		/// <summary>
-		/// The email of the user.
-		/// </summary>
-		public virtual string Email { get; set; } = string.Empty;
+        /// <summary>
+        /// The email of the user.
+        /// </summary>
+        public virtual string Email { get; set; } = string.Empty;
 
-		/// <summary>
-		/// The phone number.
-		/// </summary>
-		public virtual string? PhoneNumber { get; set; }
+        /// <summary>
+        /// The phone number.
+        /// </summary>
+        public virtual string? PhoneNumber { get; set; }
 
-		/// <summary>
-		/// Whether the user has confirmed their email address.
-		/// </summary>
-		public virtual bool EmailConfirmed { get; set; }
+        /// <summary>
+        /// Whether the user has confirmed their email address.
+        /// </summary>
+        public virtual bool EmailConfirmed { get; set; }
 
-		/// <summary>
-		/// Whether the user has confirmed their phone.
-		/// </summary>
-		public virtual bool PhoneNumberConfirmed { get; set; }
+        /// <summary>
+        /// Whether the user has confirmed their phone.
+        /// </summary>
+        public virtual bool PhoneNumberConfirmed { get; set; }
 
-		/// <summary>
-		/// Number of times sign in failed.
-		/// </summary>
-		public virtual int AccessFailedCount { get; set; }
+        /// <summary>
+        /// Number of times sign in failed.
+        /// </summary>
+        public virtual int AccessFailedCount { get; set; }
 
-		/// <summary>
-		/// Whether the user is locked out.
-		/// </summary>
-		public virtual bool LockoutEnabled { get; set; }
+        /// <summary>
+        /// Whether the user is locked out.
+        /// </summary>
+        public virtual bool LockoutEnabled { get; set; }
 
-		/// <summary>
-		/// When the user lock out is over.
-		/// </summary>
-		public virtual DateTimeOffset? LockoutEnd { get; set; }
+        /// <summary>
+        /// When the user lock out is over.
+        /// </summary>
+        public virtual DateTimeOffset? LockoutEnd { get; set; }
 
-		/// <summary>
-		/// Whether 2-factor authentication is enabled.
-		/// </summary>
-		public virtual bool TwoFactorEnabled { get; set; }
+        /// <summary>
+        /// Whether 2-factor authentication is enabled.
+        /// </summary>
+        public virtual bool TwoFactorEnabled { get; set; }
 
-		/// <summary>
-		/// The two-factor authenticator key.
-		/// </summary>
-		public string? TwoFactorAuthenticatorKey { get; set; }
+        /// <summary>
+        /// The two-factor authenticator key.
+        /// </summary>
+        public string? TwoFactorAuthenticatorKey { get; set; }
 
-		/// <summary>
-		/// The roles of the user. To modify the user's roles, use <see cref="UserManager{TUser}.AddToRoleAsync(TUser, string)"/> and <see cref="UserManager{TUser}.RemoveFromRolesAsync(TUser, IEnumerable{string})"/>.
-		/// </summary>
-		public virtual IReadOnlyList<string> Roles { 
-			get => _roles; 
-			private set => _roles = value.ToList();
-		}
+        /// <summary>
+        /// The roles of the user. To modify the user's roles, use <see cref="UserManager{TUser}.AddToRoleAsync(TUser, string)"/> and <see cref="UserManager{TUser}.RemoveFromRolesAsync(TUser, IEnumerable{string})"/>.
+        /// </summary>
+        public virtual IReadOnlyList<string> Roles { 
+            get => _roles; 
+            private set => _roles = value.ToList();
+        }
 
-		/// <summary>
-		/// The user's claims, for use in claims-based authentication.
-		/// </summary>
-		public virtual List<IdentityUserClaim> Claims { get; private set; } = new List<IdentityUserClaim>();
+        /// <summary>
+        /// The user's claims, for use in claims-based authentication.
+        /// </summary>
+        public virtual List<IdentityUserClaim> Claims { get; private set; } = new List<IdentityUserClaim>();
 
-		/// <summary>
-		/// The logins of the user.
-		/// </summary>
-		public virtual List<UserLoginInfo> Logins { get; private set; } = new List<UserLoginInfo>();
+        /// <summary>
+        /// The logins of the user.
+        /// </summary>
+        public virtual List<UserLoginInfo> Logins { get; private set; } = new List<UserLoginInfo>();
 
-		/// <summary>
-		/// The list of two factor authentication recovery codes.
-		/// </summary>
-		public virtual List<string> TwoFactorRecoveryCodes { get; set; } = new List<string>();
+        /// <summary>
+        /// The list of two factor authentication recovery codes.
+        /// </summary>
+        public virtual List<string> TwoFactorRecoveryCodes { get; set; } = new List<string>();
 
-		/// <summary>
-		/// The list authorization tokens from 3rd party authentication, e.g. Google, Microsoft, GitHub, etc.
-		/// </summary>
-		public virtual List<IdentityUserAuthToken> Tokens { get; set; } = new List<IdentityUserAuthToken>();
+        /// <summary>
+        /// The list authorization tokens from 3rd party authentication, e.g. Google, Microsoft, GitHub, etc.
+        /// </summary>
+        public virtual List<IdentityUserAuthToken> Tokens { get; set; } = new List<IdentityUserAuthToken>();
 
-		/// <summary>
-		/// Gets the mutable roles list. This shouldn't be modified by user code; roles should be changed via UserManager instead.
-		/// </summary>
-		/// <returns></returns>
-		internal List<string> GetRolesList() => _roles;
-	}
+        /// <summary>
+        /// Gets the mutable roles list. This shouldn't be modified by user code; roles should be changed via UserManager instead.
+        /// </summary>
+        /// <returns></returns>
+        internal List<string> GetRolesList() => _roles;
+    }
 
-	/// <summary>
-	/// A login claim.
-	/// </summary>
-	public class IdentityUserClaim
+    /// <summary>
+    /// A login claim.
+    /// </summary>
+    public class IdentityUserClaim
     {
         /// <summary>
         /// The type of the login claim.


### PR DESCRIPTION
When adding a user to roles with `UserManager.AddToRolesAsync`, I get an exception (see stacktrace below).
I tracked it down to the `IdentityUser` implementation which exposes `IReadOnlyList<string> Roles` but assumes the underlying implementation to be assignable to `List<string>`. When deserializing the type from RavenDB, the serializer seems to create a `ReadOnlyCollection<string>` (to best match the interface contract) which violates this assumption.

This PR makes sure that `IdentityUser.Roles` is always backed by a `List<string>`.

```
System.InvalidCastException: Unable to cast object of type 'System.Collections.ObjectModel.ReadOnlyCollection`1[System.String]' to type 'System.Collections.Generic.List`1[System.String]'.
   at Raven.Identity.IdentityUser.GetRolesList()
   at Raven.Identity.UserStore`2.AddToRoleAsync(TUser user, String roleName, CancellationToken cancellationToken)
   at Microsoft.AspNetCore.Identity.UserManager`1.AddToRolesAsync(TUser user, IEnumerable`1 roles)
```