### PR TITLE
Fix role losing users and claims when retrieved from database

### DIFF
--- a/RavenDB.Identity/IdentityRole.cs
+++ b/RavenDB.Identity/IdentityRole.cs
@@ -54,12 +54,12 @@ namespace Raven.Identity
         /// <summary>
         /// Navigation property for the users in this role.
         /// </summary>
-        public virtual ICollection<string> Users { get; } = new List<string>();
+        public virtual ICollection<string> Users { get; private set; } = new List<string>();
 
         /// <summary>
         /// Navigation property for claims in this role.
         /// </summary>
-        public virtual ICollection<TRoleClaim> Claims { get; } = new List<TRoleClaim>();
+        public virtual ICollection<TRoleClaim> Claims { get; private set; } = new List<TRoleClaim>();
 
         /// <summary>
         /// Gets or sets the primary key for this role.


### PR DESCRIPTION
This PR adds private setters to the `Users` and `Claims` properties on `IdentityRole`. 

Without these setters RavenDb can't deserialize the role correctly, leaving both the users and claims collections empty. This change then gets picked up by change tracking and on the next (maybe unrelated) call to `SaveChanges` the info in the DB gets wiped out.