### PR TITLE
Option to use static index for queries

### DIFF
--- a/RavenDB.Identity/IdentityBuilderExtensions.cs
+++ b/RavenDB.Identity/IdentityBuilderExtensions.cs
@@ -17,10 +17,11 @@ namespace Raven.Identity
 	    /// </summary>
 	    /// <typeparam name="TUser">The type of the user.</typeparam>
 	    /// <param name="builder">The builder.</param>
+	    /// <param name="configure">Options configuration callback for identity integration.</param>
 	    /// <returns></returns>
-	    public static IdentityBuilder AddRavenDbIdentityStores<TUser>(this IdentityBuilder builder) where TUser : IdentityUser
+	    public static IdentityBuilder AddRavenDbIdentityStores<TUser>(this IdentityBuilder builder, Action<RavenDbIdentityOptions>? configure = null) where TUser : IdentityUser
 	    {
-		    return builder.AddRavenDbIdentityStores<TUser, IdentityRole>();
+		    return builder.AddRavenDbIdentityStores<TUser, IdentityRole>(configure);
 	    }
 
 	    /// <summary>
@@ -29,11 +30,13 @@ namespace Raven.Identity
 	    /// <typeparam name="TUser">The type of the user.</typeparam>
 	    /// <typeparam name="TRole">The type of the role.</typeparam>
 	    /// <param name="builder">The builder.</param>
+	    /// <param name="configure">Options configuration callback for identity integration.</param>
 	    /// <returns>The builder.</returns>
-	    public static IdentityBuilder AddRavenDbIdentityStores<TUser, TRole>(this IdentityBuilder builder)
+	    public static IdentityBuilder AddRavenDbIdentityStores<TUser, TRole>(this IdentityBuilder builder, Action<RavenDbIdentityOptions>? configure = null)
 			where TUser : IdentityUser
 			where TRole : IdentityRole, new()
 		{
+			builder.Services.Configure(configure);
 			builder.Services.AddScoped<IUserStore<TUser>, UserStore<TUser, TRole>>();
 			builder.Services.AddScoped<IRoleStore<TRole>, RoleStore<TRole>>();
 

--- a/RavenDB.Identity/IdentityUserIndex.cs
+++ b/RavenDB.Identity/IdentityUserIndex.cs
@@ -1,0 +1,37 @@
+using System.Linq;
+using Raven.Client.Documents.Indexes;
+
+namespace Raven.Identity
+{
+    /// <summary>
+    /// Index to user when querying users.
+    /// </summary>
+    public class IdentityUserIndex<TUser> : AbstractIndexCreationTask<TUser, IdentityUserIndex<TUser>.Result> where TUser : IdentityUser
+    {
+        public class Result
+        {
+            public string UserName { get; set; }
+            public string Email { get; set; }
+            public string[] LoginProviderIdentifiers { get; set; }
+            public string[] Roles { get; set; }
+        }
+
+        /// <summary>
+        /// Creates the map.
+        /// </summary>
+        public IdentityUserIndex()
+        {
+            Map = users => from user in users
+                select new Result
+                {
+                    UserName = user.UserName,
+                    Email = user.Email,
+                    LoginProviderIdentifiers = user.Logins.Select(x => x.LoginProvider + "|" + x.ProviderKey).ToArray(),
+                    Roles = user.Roles.ToArray()
+                };
+        }
+
+        /// <inheritdoc />
+        public override string IndexName => "IdentityUserIndex";
+    }
+}

--- a/RavenDB.Identity/RavenDbIdentityOptions.cs
+++ b/RavenDB.Identity/RavenDbIdentityOptions.cs
@@ -1,0 +1,14 @@
+namespace Raven.Identity
+{
+    public class RavenDbIdentityOptions
+    {
+        /// <summary>
+        /// Whether to use static indexes, defaults to false.
+        /// </summary>
+        /// <remarks>
+        /// Indexes need to be deployed to server in order for static index queries to work.
+        /// </remarks>
+        /// <seealso cref="IdentityUserIndex{TUser}"/>
+        public bool UseStaticIndexes { get; set; }
+    }
+}


### PR DESCRIPTION
OK this took a bit longer than anticipated, but here goes. Now a configuration option to force queries to go trough an index, which of course needs to be deployed in order to work.

Tested with our own solution and also with sample application. Both work as expected.

fixes #33