### PR TITLE
Fixes ArgumentNullException when calling AddRavenDbIdentityStores() without a config action

### DIFF
--- a/RavenDB.Identity/IdentityBuilderExtensions.cs
+++ b/RavenDB.Identity/IdentityBuilderExtensions.cs
@@ -36,7 +36,10 @@ namespace Raven.Identity
 			where TUser : IdentityUser
 			where TRole : IdentityRole, new()
 		{
-			builder.Services.Configure(configure);
+			if (configure != null)
+			{
+				builder.Services.Configure(configure);
+			}
 			builder.Services.AddScoped<IUserStore<TUser>, UserStore<TUser, TRole>>();
 			builder.Services.AddScoped<IRoleStore<TRole>, RoleStore<TRole>>();
 


### PR DESCRIPTION
It looks like #46 introduced a bug – calling AddRavenDbIdentityStores() without a config action results in an ArgumentNullException (IServiceCollection.Configure throws if called with `configureOptions: null`).

See [OptionsServiceCollectionExtensions.cs Lines 43 and 58](https://github.com/dotnet/runtime/blob/522c281d5e2ccbfa9a114018a7309965571ab4b6/src/libraries/Microsoft.Extensions.Options/src/OptionsServiceCollectionExtensions.cs#L43)