### PR TITLE
Add SaveChanges after delete user

### DIFF
--- a/RavenDB.Identity/UserStore.cs
+++ b/RavenDB.Identity/UserStore.cs
@@ -160,6 +160,8 @@ namespace Raven.Identity
                 // We need to manually roll it back.
                 logger.LogError("Error during user creation", createUserError);
                 DbSession.Delete(user); // It's possible user is already saved to the database. If so, delete him.
+                DbSession.SaveChangesAsync(cancellationToken);
+                
                 try
                 {
                     await this.DeleteEmailReservation(user.Email!);


### PR DESCRIPTION
RavenDB docs states that [entities can be marked for deletion by using the Delete method, but will not be removed from the server until SaveChanges is called](https://ravendb.net/docs/article-page/6.0/csharp/client-api/session/deleting-entities#session-deleting-entities)

Fix #50 