### PR TITLE
Support static index in UserStore.FindByEmailAsync

### DIFF
--- a/RavenDB.Identity/UserStore.cs
+++ b/RavenDB.Identity/UserStore.cs
@@ -561,21 +561,28 @@ namespace Raven.Identity
         }
 
         /// <inheritdoc />
-#pragma warning disable CS8613 // Nullability of reference types in return type doesn't match implicitly implemented member.
         public virtual async Task<TUser?> FindByEmailAsync(string normalizedEmail, CancellationToken cancellationToken)
-#pragma warning restore CS8613 // Nullability of reference types in return type doesn't match implicitly implemented member.
         {
+            if (options.Value.UseStaticIndexes)
+            {
+                return await DbSession.Query<IdentityUserIndex<TUser>.Result, IdentityUserIndex<TUser>>()
+                    .Where(u => u.Email == normalizedEmail)
+                    .As<TUser>()
+                    .FirstOrDefaultAsync(cancellationToken);
+            }
+
             // While we could just do an index query here: DbSession.Query<TUser>().FirstOrDefaultAsync(u => u.Email == normalizedEmail)
             // We decided against this because indexes can be stale.
             // Instead, we're going to go straight to the compare/exchange values and find the user for the email.
             var key = Conventions.CompareExchangeKeyFor(normalizedEmail);
-            var readResult = await DbSession.Advanced.DocumentStore.Operations.ForDatabase(((AsyncDocumentSession)DbSession).DatabaseName).SendAsync(new GetCompareExchangeValueOperation<string>(key));
+            var operations = DbSession.Advanced.DocumentStore.Operations.ForDatabase(((AsyncDocumentSession)DbSession).DatabaseName);
+            var readResult = await operations.SendAsync(new GetCompareExchangeValueOperation<string>(key), token: cancellationToken);
             if (readResult == null || string.IsNullOrEmpty(readResult.Value))
             {
                 return null;
             }
 
-            return await DbSession.LoadAsync<TUser>(readResult.Value);
+            return await DbSession.LoadAsync<TUser>(readResult.Value, cancellationToken);
         }
 
         /// <inheritdoc />


### PR DESCRIPTION
Boy did I have fun time trying to figure out why some user-related features were failing. Long story short - for some reason the compare exchange value was missing and user was reported as not found on email based query even though everything looked OK in user data.

As static indexes are supported when querying user by username, I guess it would be fitting to use the index in case of querying by email. The scenario of index being stale here seems a bit far-fetched as emails change very rarely.